### PR TITLE
Fix type mismatch of `invokeSubscribe()`

### DIFF
--- a/lib/composables/useSubscriptionGraphqlClient.js
+++ b/lib/composables/useSubscriptionGraphqlClient.js
@@ -19,7 +19,7 @@ import {
  *   capsuleRef: import('vue').Ref<InstanceType<C>>
  *   invokeSubscribe: (args: {
  *     hooks: furo.GraphqlSubscriberHooks
- *     variables?: furo.GraphqlRequestVariables
+ *     valueHash: Record<string, *>
  *     operationName?: string | null
  *     extensions?: Record<string, unknown>
  *     context?: {


### PR DESCRIPTION
# Why

* Close #007

# How

* Replace the mismatched `variables` with `valueHash`.
